### PR TITLE
feat: add method to calculate total tries from questions and update r…

### DIFF
--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -58,6 +58,7 @@ export class GameService {
     return {
       success: true,
       data: gameToken,
+      tries: this.addUpTries(game.listOfQuestions),
       error: null,
     };
   }
@@ -111,6 +112,14 @@ export class GameService {
       points += questions[i].score;
     }
     return points;
+  }
+
+  addUpTries(questions: QuestionSendBack[]) {
+    let tries = 0;
+    for (let i = 0; i < questions.length; i++) {
+      tries += questions[i].trys;
+    }
+    return tries;
   }
 
   getQuestions(getQuestionDto: GetQuestionDto, userId: string) {
@@ -202,6 +211,7 @@ export class GameService {
     return {
       success: true,
       gameStatus: gameStatus,
+      tries: this.addUpTries(gs.game.listOfQuestions),
       data: gameToken,
     };
   }


### PR DESCRIPTION
This pull request introduces a new method, `addUpTries`, to the `GameService` class in `backend/src/game/game.service.ts`. This method calculates the total number of tries from a list of questions and integrates this functionality into relevant parts of the service.

### Key Changes:

#### New Method Addition:
* Added the `addUpTries` method to calculate the total number of tries from the `listOfQuestions` array. It iterates through the questions and sums up their `trys` values.

#### Integration of `addUpTries`:
* Updated the `return` object in two methods of `GameService` to include the total tries:
  - Added `tries` to the response in the method handling `gameToken` creation.
  - Added `tries` to the response in the method handling game status retrieval.