### PR TITLE
feat: add leaderboard retrieval endpoint and service method with limi…

### DIFF
--- a/backend/src/game/dto/limit.dto.ts
+++ b/backend/src/game/dto/limit.dto.ts
@@ -1,0 +1,7 @@
+import { IsInt, IsNotEmpty } from 'class-validator';
+
+export default class LimitDto {
+  @IsInt({ message: 'Limit must be an integer' })
+  @IsNotEmpty({ message: 'Limit cannot be empty' })
+  limit: number;
+}

--- a/backend/src/game/game.controller.ts
+++ b/backend/src/game/game.controller.ts
@@ -1,10 +1,19 @@
-import { Controller, Get, Body, Post, UseGuards, Req } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Body,
+  Post,
+  UseGuards,
+  Req,
+  Param,
+} from '@nestjs/common';
 import { GameService } from './game.service';
 import { StartGameDto } from './dto/start-game.dto';
 import { CheckGameDto } from './dto/check-game.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { Request } from 'express';
 import { GetQuestionDto } from './dto/get-question.dto';
+import LimitDto from './dto/limit.dto';
 
 @Controller('game')
 export class GameController {
@@ -32,6 +41,18 @@ export class GameController {
       };
     }
     return this.gameService.getQuestions(getQuestionDto, req.user.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('/leader/:limit')
+  getLeaderBoard(@Param('limit') limitDto: LimitDto, @Req() req: Request) {
+    if (!req.user) {
+      return {
+        success: false,
+        error: 'User not found',
+      };
+    }
+    return this.gameService.getLeaderBoard(limitDto.limit);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -3,7 +3,7 @@ import { StartGameDto } from './dto/start-game.dto';
 import { CheckGameDto } from './dto/check-game.dto';
 import { DbService } from '../db/db.service';
 import { SimpleQuestionTable } from '../db/schema/question';
-import { eq } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 import { Game, QuestionSendBack } from './entities/game.entity';
 import { JwtService } from '@nestjs/jwt';
 import { GetQuestionDto } from './dto/get-question.dto';
@@ -16,6 +16,30 @@ export class GameService {
     private readonly dbService: DbService,
     private readonly jwtService: JwtService,
   ) {}
+
+  async getLeaderBoard(limit: number) {
+    const dbCheck = await this.dbService.db
+      .select({
+        id: UserTable.id,
+        username: UserTable.username,
+        points: UserTable.points,
+      })
+      .from(UserTable)
+      .orderBy(desc(UserTable.points))
+      .limit(limit);
+    if (dbCheck.length === 0) {
+      return {
+        success: false,
+        data: null,
+        error: 'No users found',
+      };
+    }
+    return {
+      success: true,
+      data: dbCheck,
+      error: null,
+    };
+  }
 
   async start(startGameDto: StartGameDto, userId: string) {
     const dbCheck = await this.dbService.db
@@ -107,7 +131,6 @@ export class GameService {
         error: 'User not found',
       };
     }
-    
     const res = await this.dbService.db
       .update(UserTable)
       .set({


### PR DESCRIPTION
This pull request introduces a new leaderboard feature to the game module, allowing users to retrieve a ranked list of players based on their points. The changes include adding a new DTO for input validation, extending the `GameController` with a new endpoint, and implementing the leaderboard logic in the `GameService`.

### New leaderboard feature:

* **Added `LimitDto` for input validation**:
  - Introduced a new DTO, `LimitDto`, in `backend/src/game/dto/limit.dto.ts` to validate the `limit` parameter as a non-empty integer.

* **Extended `GameController` with a new leaderboard endpoint**:
  - Added a `GET /leader/:limit` endpoint in `GameController` to fetch the leaderboard. The endpoint uses `JwtAuthGuard` for authentication and validates the `limit` parameter using `LimitDto`.
  - Updated imports in `backend/src/game/game.controller.ts` to include `LimitDto` and `Param`.

* **Implemented leaderboard logic in `GameService`**:
  - Added a `getLeaderBoard` method in `GameService` to query the database for the top users, ordered by points, with a limit on the number of results. Returns appropriate success or error responses.
  - Updated imports in `backend/src/game/game.service.ts` to include the `desc` function for ordering results by points.

### Minor improvements:

* **Code cleanup in `GameService`**:
  - Removed unnecessary whitespace for better code formatting.